### PR TITLE
Enable simplification of floating point division in simplify_expr

### DIFF
--- a/regression/goto-analyzer/constant_propagation_float_div/main.c
+++ b/regression/goto-analyzer/constant_propagation_float_div/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+
+#define ROUND(x) (int)((x)>0.0?(x)+0.5 : (x)-0.5)
+
+const int C1 = ROUND(100./8.);
+const int C2 = 100/8;
+const int C3 = 13;
+int g_in;
+int g_out;
+
+void func(void)
+{
+  if (g_in > C1)
+    g_out = 1;    // (1)
+  if (g_in > C2)
+    g_out = 2;    // (2)
+  if (g_in > C3)
+    g_out = 3;    // (3)
+}
+
+void main(void)
+{
+  g_in = 0;
+  g_out = 0;
+  func();
+  assert(!g_out);
+}

--- a/regression/goto-analyzer/constant_propagation_float_div/test.desc
+++ b/regression/goto-analyzer/constant_propagation_float_div/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--variable --verify
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] file main.c line 26 function main, assertion !g_out: Success
+

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -383,6 +383,27 @@ bool simplify_exprt::simplify_div(exprt &expr)
       }
     }
   }
+  else if(expr.type().id() == ID_floatbv)
+  {
+    if(expr.op1().is_constant() &&
+        expr.op1().is_one())
+    {
+      exprt tmp;
+      tmp.swap(expr.op0());
+      expr.swap(tmp);
+      return false;
+    }
+    if(expr.op0().is_constant() &&
+        expr.op1().is_constant())
+    {
+      ieee_floatt f0, f1;
+      f0.from_expr(to_constant_expr(expr.op0()));
+      f1.from_expr(to_constant_expr(expr.op1()));
+      f0/=f1;
+      expr = f0.to_expr();
+      return false;
+    }
+  }
 
   return true;
 }


### PR DESCRIPTION
Note that it's goto-analyzer that had problems with this, cbmc seems to work fine with the test case even without this change somehow