### PR TITLE
Variable sensitivity branch floating point

### DIFF
--- a/regression/goto-analyzer/variable-sensitivity-floating-point-simplification/main.c
+++ b/regression/goto-analyzer/variable-sensitivity-floating-point-simplification/main.c
@@ -1,0 +1,41 @@
+#include <assert.h>
+
+int main(void)
+{
+  const float one = 1.0f;
+  // Check that rounding mode affects behavior
+
+  // default rounding mode towards nearest
+  float big_0_1 = one / 10.0f;
+  __CPROVER_rounding_mode = 1; // round to -∞
+  float small_0_1 = one / 10.0f;
+  assert(small_0_1 < big_0_1);
+
+  // Check that exact operations still work with unknown rounding mode
+  int some_condition;
+  if(some_condition)
+  {
+    __CPROVER_rounding_mode = 3;
+  }
+  // rounding mode is TOP now
+
+  // regardless of rounding mode,
+  // 1/10 is definitely smaller than 0.2
+  assert(one / 10.0f < 0.2f);
+
+  // This is unknown because
+  // we don't know the value of one_tenth_ish
+  // (could be slightly less or slightly more than 0.1)
+  // This is contrast to above, where we didn't need
+  // to know the exact value of one/10.0f, just
+  // that it is less than 0.2f
+  float one_tenth_ish = one / 10.0f;
+  assert(one_tenth_ish < 0.2f);
+
+  // regardless of rounding mode,
+  // 10/5 is still 2
+  float five = 5.0f;
+  assert(10.0f / five == 2.0f);
+
+  return 0;
+}

--- a/regression/goto-analyzer/variable-sensitivity-floating-point-simplification/test.desc
+++ b/regression/goto-analyzer/variable-sensitivity-floating-point-simplification/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--variable --verify
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] file main.c line \d\d function main, assertion small_0_1 < big_0_1: Success
+^\[main.assertion.2\] file main.c line \d\d function main, assertion one / 10.0f < 0.2f: Success
+^\[main.assertion.3\] file main.c line \d\d function main, assertion one_tenth_ish < 0.2f: Unknown
+^\[main.assertion.4\] file main.c line \d\d function main, assertion 10.0f / five == 2.0f: Success

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -15,6 +15,7 @@
 #include <util/std_expr.h>
 #include <util/simplify_expr.h>
 #include <util/type.h>
+#include <goto-programs/adjust_float_expressions.h>
 
 #include "abstract_object.h"
 
@@ -182,12 +183,14 @@ abstract_object_pointert abstract_objectt::expression_transform(
   const abstract_environmentt &environment,
   const namespacet &ns) const
 {
-  exprt constant_replaced_expr=expr;
+  exprt adjusted_expr = expr;
+  adjust_float_expressions(adjusted_expr, ns);
+  exprt constant_replaced_expr = adjusted_expr;
   constant_replaced_expr.operands().clear();
 
   // Two passes over the expression - one for simplification,
   // another to check if there are any top subexpressions left
-  for(const exprt &op : expr.operands())
+  for(const exprt &op : adjusted_expr.operands())
   {
     abstract_object_pointert lhs_abstract_object=environment.eval(op, ns);
     const exprt &lhs_value=lhs_abstract_object->to_constant();
@@ -204,7 +207,6 @@ abstract_object_pointert abstract_objectt::expression_transform(
       constant_replaced_expr.operands().push_back(lhs_value);
     }
   }
-
   exprt simplified = simplify_expr(constant_replaced_expr, ns);
 
   for(const exprt &op : simplified.operands())

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -255,6 +255,11 @@ protected:
   // The one exception is merge in descendant classes, which needs this
   void make_top() { top=true; this->make_top_internal(); }
   void clear_top() { top=false; this->clear_top_internal(); }
+
+  abstract_object_pointert try_transform_expr_with_all_rounding_modes(
+    const exprt &expr,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
 };
 
 template<typename keyt>

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/c_preprocess.h>
 
+#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/convert_nondet.h>
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
@@ -52,7 +53,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/string_instrumentation.h>
 
 #include <goto-symex/rewrite_union.h>
-#include <goto-symex/adjust_float_expressions.h>
 
 #include <goto-instrument/full_slicer.h>
 #include <goto-instrument/nondet_static.h>

--- a/src/clobber/Makefile
+++ b/src/clobber/Makefile
@@ -13,7 +13,6 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
        ../assembler/assembler$(LIBEXT) \
        ../solvers/solvers$(LIBEXT) \
        ../util/util$(LIBEXT) \
-       ../goto-symex/adjust_float_expressions$(OBJEXT) \
        ../goto-symex/rewrite_union$(OBJEXT) \
        ../pointer-analysis/dereference$(OBJEXT) \
        ../goto-instrument/dump_c$(OBJEXT) \

--- a/src/goto-diff/Makefile
+++ b/src/goto-diff/Makefile
@@ -25,7 +25,6 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../goto-instrument/cover_instrument_mcdc$(OBJEXT) \
       ../goto-instrument/cover_instrument_other$(OBJEXT) \
       ../goto-instrument/cover_util$(OBJEXT) \
-      ../goto-symex/adjust_float_expressions$(OBJEXT) \
       ../goto-symex/rewrite_union$(OBJEXT) \
       ../analyses/analyses$(LIBEXT) \
       ../langapi/langapi$(LIBEXT) \

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -24,6 +24,7 @@ Author: Peter Schrammel
 
 #include <langapi/language.h>
 
+#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/mm_io.h>
@@ -47,7 +48,6 @@ Author: Peter Schrammel
 #include <goto-programs/link_to_library.h>
 
 #include <goto-symex/rewrite_union.h>
-#include <goto-symex/adjust_float_expressions.h>
 
 #include <goto-instrument/cover.h>
 

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -1,4 +1,5 @@
-SRC = basic_blocks.cpp \
+SRC = adjust_float_expressions.cpp \
+      basic_blocks.cpp \
       builtin_functions.cpp \
       class_hierarchy.cpp \
       class_identifier.cpp \

--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -18,7 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ieee_float.h>
 #include <util/arith_tools.h>
 
-#include <goto-programs/goto_model.h>
+#include "goto_model.h"
 
 static bool have_to_adjust_float_expressions(
   const exprt &expr,

--- a/src/goto-programs/adjust_float_expressions.h
+++ b/src/goto-programs/adjust_float_expressions.h
@@ -9,8 +9,8 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution
 
-#ifndef CPROVER_GOTO_SYMEX_ADJUST_FLOAT_EXPRESSIONS_H
-#define CPROVER_GOTO_SYMEX_ADJUST_FLOAT_EXPRESSIONS_H
+#ifndef CPROVER_GOTO_PROGRAMS_ADJUST_FLOAT_EXPRESSIONS_H
+#define CPROVER_GOTO_PROGRAMS_ADJUST_FLOAT_EXPRESSIONS_H
 
 #include <goto-programs/goto_functions.h>
 
@@ -31,4 +31,4 @@ void adjust_float_expressions(
   const namespacet &ns);
 void adjust_float_expressions(goto_modelt &goto_model);
 
-#endif // CPROVER_GOTO_SYMEX_ADJUST_FLOAT_EXPRESSIONS_H
+#endif // CPROVER_GOTO_PROGRAMS_ADJUST_FLOAT_EXPRESSIONS_H

--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -1,5 +1,4 @@
-SRC = adjust_float_expressions.cpp \
-      auto_objects.cpp \
+SRC = auto_objects.cpp \
       build_goto_trace.cpp \
       goto_symex.cpp \
       goto_symex_state.cpp \

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -25,6 +25,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/ansi_c_language.h>
 
+#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/convert_nondet.h>
 #include <goto-programs/lazy_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
@@ -43,8 +44,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/show_goto_functions.h>
 #include <goto-programs/show_symbol_table.h>
 #include <goto-programs/show_properties.h>
-
-#include <goto-symex/adjust_float_expressions.h>
 
 #include <goto-instrument/full_slicer.h>
 #include <goto-instrument/nondet_static.h>


### PR DESCRIPTION
This allows floating point simplification that respects the current rounding mode in the variable sensitivity domain.

For this purpose, adjust_float_expressions is moved to goto-programs from goto-symex.

In variable sensitivity, we then use adjust_float_expressions to change generic arithmetic expressions to their floating point counterparts (that have a rounding mode attached to them). Furthermore, before trying to evaluate the expression we check if the current rounding mode is known, and if not we evaluate it with all rounding modes to see if the expression changes depending on rounding mode. If it doesn't, we can still evaluate it.